### PR TITLE
[FIX] Added uglify-js as dependancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "shipit-deploy": "2.2",
     "shipit-shared": "4.4.1",
     "slack-node": "~0.1.3",
+    "uglify-js": "^3.7.5",
     "socket.io": "~1.4.5"
   }
 }


### PR DESCRIPTION
This package is required for Devflow to work.
before that patch DevOps had to install that package in every server.